### PR TITLE
feat: change Task form to use description instead of collaborators

### DIFF
--- a/website/routes.py
+++ b/website/routes.py
@@ -148,7 +148,7 @@ def submitAddTask():
     # Get the form data
     print("We are here in the task submit bit!")
     name = request.form['taskName']
-    collabs = request.form['taskCollabs']
+    description = request.form['taskDescription']  # Changed from taskCollabs to taskDescription
     dueDate = request.form['taskDueDate']
     parentProject = request.form.get('project_id')  # Get the parent project ID from the form
 
@@ -158,7 +158,8 @@ def submitAddTask():
     # Create a new task instance
     new_task = Task(
         name=name,
-        collabs=collabs,
+        description=description,  # Store the description in the description field
+        collabs="Unassigned",  # Set a default value as collabs field is non-nullable
         dueDate=dueDate,
         parentProject=parentProject,
         status=0  
@@ -174,7 +175,7 @@ def submitAddTask():
         action=f"New task added"
     )
 
-    print("New task created: ", new_task.name, new_task.collabs, new_task.dueDate, new_task.parentProject)
+    print("New task created: ", new_task.name, new_task.description, new_task.dueDate, new_task.parentProject)
     # Add the new task to the database session and commit
     db.session.add(new_activity)
     db.session.commit()

--- a/website/templates/project_view.html
+++ b/website/templates/project_view.html
@@ -246,10 +246,10 @@
         <label for="taskDueDate" class="block text-sm font-medium text-slate-700">Due Date</label>
         <input type="date" id="taskDueDate" name="taskDueDate" class="mt-1 block w-full border border-slate-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500" required>
       </div>
-      <div class="mb-4">
-        <label for="taskCollabs" class="block text-sm font-medium text-slate-700">Collaborators</label>
-        <textarea id="taskCollabs" name="taskCollabs" rows="3" class="mt-1 block w-full border border-slate-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500"></textarea>
-      </div>
+    <div class="mb-4">
+      <label for="taskDescription" class="block text-sm font-medium text-slate-700">Description</label>
+      <textarea id="taskDescription" name="taskDescription" rows="3" class="mt-1 block w-full border border-slate-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500"></textarea>
+    </div>
       <input type="hidden" name="project_id" value="{{ project.id }}" id="project_id">
       <button type="submit" class="btn-primary px-5 py-2.5 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700">Add Task </button>
     </form>


### PR DESCRIPTION
- Changed the input field label from 'Collaborators' to 'Description' in New Task modal
- Updated form field name from taskCollabs to taskDescription
- Modified submitAddTask route to store input in task.description field
- Set default value of 'Unassigned' for the required collabs field
- Updated console logging to show description field

This improves usability by allowing users to add meaningful descriptions to tasks and displays them properly in the task view pages.

Closes #46