### PR TITLE
Fixed missing JS script link

### DIFF
--- a/website/templates/project_view.html
+++ b/website/templates/project_view.html
@@ -253,6 +253,8 @@
     </button>
   </div>
 </div>
+<script src="{{ url_for('static', filename='js/projectdetails.js') }}"></script> 
+<script src="{{ url_for('static', filename='js/invite.js') }}"></script> 
 {% endblock %}
 
 {% block extra_js %}


### PR DESCRIPTION
Fixed JS Link in the project_view page, which corresponded to unittest fails